### PR TITLE
updating stylegan github repo link

### DIFF
--- a/3_StyleGAN.ipynb
+++ b/3_StyleGAN.ipynb
@@ -207,8 +207,7 @@
         "In February 2019, NVIDIA announced that it was open sourcing a tool that generates hyper-realistic images of faces using StyleGAN. The model is trained on the Flickr Faces dataset, which contains 70,000 high-quality PNG images of human faces. The images are at 1,024 x 1,024 resolution and were first aligned and cropped. Users of the open source tool can either use the pretrained model or train their own model in order to generate images of\n",
         "faces.\n",
         "\n",
-        "The tool can be downloaded by cloning the GitHub repository at: [https://github.com/\n",
-        "NVlabs/stylegan.git.](https://github.com/NVlabs/stylegan.git.)"
+        "The tool can be downloaded by cloning the GitHub repository at: [https://github.com/NVlabs/stylegan2-ada.git](https://github.com/NVlabs/stylegan2-ada.git)."
       ]
     }
   ]


### PR DESCRIPTION
changing  "The tool can be downloaded by cloning the GitHub repository at: [https://github.com/%20NVlabs/stylegan.git.](https://github.com/%20NVlabs/stylegan.git.)"
to "The tool can be downloaded by cloning the GitHub repository at: [https://github.com/NVlabs/stylegan2-ada.git](https://github.com/NVlabs/stylegan2-ada.git)."